### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/server/utils/minio_connection.py
+++ b/server/utils/minio_connection.py
@@ -9,8 +9,9 @@ class MinioStorage:
         self.entrypoint = config.s3_url
         self.access_key = config.s3_access_key
         self.secret_key = config.s3_secret_key
+        masked_secret_key = self.secret_key[:4] + "****" + self.secret_key[-4:]
         output_log(
-            f"Minio connection to {self.entrypoint} with {self.access_key} and {self.secret_key}",
+            f"Minio connection to {self.entrypoint} with {self.access_key} and {masked_secret_key}",
             "debug",
         )
         self.client = Minio(


### PR DESCRIPTION
Potential fix for [https://github.com/Noahdingpeng/peng-agent/security/code-scanning/7](https://github.com/Noahdingpeng/peng-agent/security/code-scanning/7)

To fix the problem, we need to ensure that sensitive information such as `config.s3_secret_key` is not logged in clear text. Instead, we can mask or omit the sensitive parts of the log messages. Specifically, we should modify the log message in `server/utils/minio_connection.py` to exclude the secret key or replace it with a masked version.

1. In `server/utils/minio_connection.py`, modify the log message to exclude the secret key or replace it with a masked version.
2. Ensure that the `output_log` function in `server/utils/log.py` does not log sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
